### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Selenium_ browser test abstraction.
 .. image:: https://travis-ci.org/tysonclugg/selenium_page_adapter.svg?branch=master
     :target: https://travis-ci.org/tysonclugg/selenium_page_adapter
     :alt: Build Status
-.. image:: https://pypip.in/v/selenium_page_adapter/badge.png
+.. image:: https://img.shields.io/pypi/v/selenium_page_adapter.svg
     :target: https://pypi.python.org/pypi/selenium_page_adapter/
     :alt: selenium_page_adapter on PyPi
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20selenium-page-adapter))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `selenium-page-adapter`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.